### PR TITLE
DRIN-12 docs: update copyright year to 2023

### DIFF
--- a/src/layout/main/Footer.jsx
+++ b/src/layout/main/Footer.jsx
@@ -10,7 +10,7 @@ const Footer = () => {
         <Row className="align-items-center">
           <Col xs={12} md={6} lg={7}>
             <p className="text-center text-md-start my-auto">
-              © 2021 Created by{" "}
+              © 2023 Created by{" "}
               <a
                 className="text-white fw-bold text-decoration-none"
                 href="https://github.com/JacquelineFM"


### PR DESCRIPTION
- Update the copyright year in the footer of the website from 2021 to 2023 to keep it up-to-date.

![image](https://user-images.githubusercontent.com/69128578/220214425-595e5c15-0412-4fbb-8593-211eeb5033b7.png)
