### PR TITLE
DRIN-13 feat: add loading spinner

### DIFF
--- a/src/components/LoadingScreen.jsx
+++ b/src/components/LoadingScreen.jsx
@@ -1,0 +1,31 @@
+import PropTypes from "prop-types";
+// react-bootstrap
+import { Spinner } from "react-bootstrap";
+
+// ----------------------------------------------------------------------
+
+const LoadingScreen = ({ variant, animation, className }) => {
+  return (
+    <Spinner
+      variant={variant}
+      animation={animation}
+      className={`d-flex mx-auto ${className}`}
+    />
+  );
+};
+
+export default LoadingScreen;
+
+// ----------------------------------------------------------------------
+
+LoadingScreen.propTypes = {
+  variant: PropTypes.string.isRequired,
+  animation: PropTypes.string,
+  className: PropTypes.string,
+};
+
+LoadingScreen.defaultProps = {
+  variant: "primary",
+  animation: "border",
+  className: "",
+};

--- a/src/sections/drinks/ModalDrink.jsx
+++ b/src/sections/drinks/ModalDrink.jsx
@@ -1,5 +1,7 @@
 // react-bootstrap
 import { Modal } from "react-bootstrap";
+// components
+import LoadingScreen from "../../components/LoadingScreen";
 // hooks
 import useDrinks from "../../hooks/useDrinks";
 //
@@ -10,11 +12,15 @@ import ModalBody from "./ModalDrink/ModalBody";
 const ModalDrink = () => {
   const { recipe, modal, loading, handleModalClick } = useDrinks();
 
+  const modalBodyContent = loading ? (
+    <LoadingScreen />
+  ) : (
+    <ModalBody recipe={recipe} />
+  );
+
   return (
     <Modal size="lg" centered show={modal} onHide={handleModalClick}>
-      <Modal.Body className="show-grid p-4">
-        {loading ? null : <ModalBody recipe={recipe} />}
-      </Modal.Body>
+      <Modal.Body className="show-grid p-4">{modalBodyContent}</Modal.Body>
     </Modal>
   );
 };


### PR DESCRIPTION
- Implement the add loading spinner issue by adding a LoadingScreen component to the ModalBody.
- The LoadingScreen displays a Spinner to indicate when the selected drink information is loading.

# **Desktop**

![image](https://user-images.githubusercontent.com/69128578/222313781-2490604b-0c2e-4626-a03c-4b6af1a02ea6.png)

# **Mobile**

![image](https://user-images.githubusercontent.com/69128578/222313693-f6dd2d9d-9775-43bf-a0b3-1a194b5394ca.png)
